### PR TITLE
Switch to more universal su vs. sudo

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/General.pm
+++ b/scripts/ZoneMinder/lib/ZoneMinder/General.pm
@@ -99,7 +99,7 @@ sub getCmdFormat {
 
   my $null_command = "true";
 
-  my $prefix = "sudo -u ".$Config{ZM_WEB_USER}." ";
+  my $prefix = "su ".$Config{ZM_WEB_USER}." -c ";
   my $suffix = "";
   my $command = $prefix.$null_command.$suffix;
   Debug( "Testing \"$command\"\n" );


### PR DESCRIPTION
I don't have `sudo` on my servers. ZoneMinder is able to start up given the the changes I made here. 